### PR TITLE
Update EmuleSecurity.cs

### DIFF
--- a/Code/IPFilter/ListProviders/EmuleSecurity.cs
+++ b/Code/IPFilter/ListProviders/EmuleSecurity.cs
@@ -26,7 +26,7 @@ namespace IPFilter.ListProviders
         {
             if(string.Equals("Default", mirror.Id, StringComparison.OrdinalIgnoreCase))
             {
-                return "http://upd.emule-security.org/ipfilter.zip";
+                return "https://upd.emule-security.org/ipfilter.zip";
             }
 
             throw new ArgumentOutOfRangeException();


### PR DESCRIPTION
Please note that BlocklistMirrorProvider.cs could not be updated accordingly since I-Blocklist free subscription does not cover HTTPS connections.